### PR TITLE
Add a dummy user with uid 1000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,15 @@ FROM node
 
 RUN npm install -g ember-cli@0.1.0 bower
 
-RUN groupadd -f -g 1000 dummy && \
-    useradd -u 1000 -g dummy dummy && \
-    mkdir --parent /home/dummy && \
-    chown -R dummy:dummy /home/dummy
+RUN apt-get update --quiet && apt-get install --quiet --yes sudo
+RUN groupadd --force user && \
+    useradd --gid user user && \
+    mkdir --parent /home/user && \
+    chown -R user:user /home/user
+
+ADD as_user /usr/local/bin/as_user
 
 EXPOSE 4200 35729
 WORKDIR /usr/src/app
-ENTRYPOINT ["/usr/local/bin/ember"]
+ENTRYPOINT ["/usr/local/bin/as_user", "/usr/local/bin/ember"]
 CMD ["help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@ FROM node
 
 RUN npm install -g ember-cli@0.1.0 bower
 
+RUN groupadd -f -g 1000 dummy && \
+    useradd -u 1000 -g dummy dummy && \
+    mkdir --parent /home/dummy && \
+    chown -R dummy:dummy /home/dummy
+
 EXPOSE 4200 35729
 WORKDIR /usr/src/app
 ENTRYPOINT ["/usr/local/bin/ember"]

--- a/as_user
+++ b/as_user
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# This is a hack to run a command as a normal user with choosen uid/gid. This way,
+# files that get created in bind-mounted volumes are not inevitably owned by root.
+#
+# This hack will be useless once Docker supports user mapping.
+#
+# If USER_UID and USER_GID are set, it changes user uid/gid to the given values
+# and run given command with this user
+# else it runs normally as root
+
+numeric_re='^[0-9]+$'
+
+if [ -z "$USER_UID" -a -z "$USER_GID" ]
+then
+  exec "$@"
+elif [ -z "$USER_UID" ]
+then
+  echo "missing USER_UID" >&2
+  exit 1
+elif [ -z "$USER_GID" ]
+then
+  echo "missing USER_GID" >&2
+  exit 1
+elif ! [[ $USER_UID =~ $numeric_re ]]
+then
+  echo "given USER_UID is not a number" >&2
+  exit 1
+elif ! [[ $USER_GID =~ $numeric_re ]]
+then
+  echo "given USER_GID is not a number" >&2
+  exit 1
+else
+  [ $USER_UID = $(id --user user) ] || usermod --non-unique --uid $USER_UID user
+  [ $USER_GID = $(id --group user) ] || groupmod --non-unique --gid $USER_GID user
+  exec sudo -u user -- "$@"
+fi


### PR DESCRIPTION
I find the usage of `fig` fantastic and created aliases to run ember easily:

```
alias ember='fig --file ~/.ember-cli.fig.yml run --rm ember'
```

Yet, files created with `ember new my-app` are all owned by root. To prevent this, I created a new image from yours with a dummy user having the same uid as me. I modified the fig.yml file to run as this dummy user:

```
# Copied from https://registry.hub.docker.com/u/geoffreyd/ember-cli/
# Allows using ember-cli without installing npm and bower

ember: &defaults
  image: cbliard/ember-cli-custom
  user: dummy
  volumes:
    - .:/usr/src/app #if your on docker actual

server:
  <<: *defaults
  command: server --watcher polling
  ports:
    - 4200:4200
    - 35729:35729

npm:
  <<: *defaults
  entrypoint: ['/usr/local/bin/npm']

bower:
  <<: *defaults
  entrypoint: ['/usr/local/bin/bower', '--allow-root']
```

Now when I run `ember new my-app`, the created files have the expected owner/group.

User mapping is planned for Docker, but for the moment it has been a useful hack for me.
